### PR TITLE
Add module statement to package.json and restore cmp check

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "@babel/runtime-corejs3": "^7.9.6"
   },
   "main": "dist/index.js",
+  "module": "src/index.js",
   "publishConfig": {
     "registry": "http://vault.cnvrmedia.net/nexus/content/repositories/npm-internal/"
   }

--- a/src/lib/pubcidHandler.js
+++ b/src/lib/pubcidHandler.js
@@ -22,7 +22,7 @@ export default class PubcidHandler {
             extend: true,
             pixelUrl: '',
             consent: {
-                type: '',
+                type: 'iab',
                 alwaysCallback: true
             }
         };


### PR DESCRIPTION
Adding a module statement to help IDE when importing pubcid as a module.  Also restore default checking for CMP, if available.