### PR TITLE
Feature/202011/delete both locations/mpub 15632

### DIFF
--- a/src/lib/constants.js
+++ b/src/lib/constants.js
@@ -1,0 +1,2 @@
+export const COOKIE = 'cookie';
+export const LOCAL_STORAGE = 'html5';

--- a/src/lib/storageUtils.js
+++ b/src/lib/storageUtils.js
@@ -1,4 +1,6 @@
 import log from './log';
+import {COOKIE, LOCAL_STORAGE} from "./constants";
+import {delCookie, getCookie, setCookie} from "./cookieUtils";
 
 const EXP_SUFFIX = '_exp';
 
@@ -114,5 +116,59 @@ export function removeStorageItem(key) {
     }
     catch(e) {
         log.debug(e);
+    }
+}
+
+/**
+ * Read a value by checking cookies first and then local storage.
+ * @param {string} type Storage type
+ * @param {string} name Name of the item
+ * @returns {string|null} a string if item exists
+ */
+export function readValue(type, name) {
+    let value;
+
+    if (type === COOKIE) {
+        value = getCookie(name);
+    } else if (type === LOCAL_STORAGE) {
+        value = getStorageItem(name);
+    }
+
+    if (value === 'undefined' || value === 'null')
+        return null;
+
+    return value;
+}
+
+/**
+ * Write a value to cookies or local storage
+ * @param {string} type Storage type
+ * @param {string} name Name of the item
+ * @param {string} value Value to be stored
+ * @param {number} expInterval Expiry time in minutes
+ * @param {string} domain Cookie cookieDomain
+ */
+export function writeValue(type, name, value, expInterval, domain) {
+    if (name && value) {
+        if (type === COOKIE) {
+            setCookie(name, value, expInterval, domain, '/', 'Lax');
+        } else if (type === LOCAL_STORAGE) {
+            setStorageItem(name, value, expInterval);
+        }
+    }
+}
+
+/**
+ * Delete value from cookies or local storage
+ * @param {string} type Storage type
+ * @param {string} name Name of the item
+ */
+export function deleteValue(type, name) {
+    if (name) {
+        if (type === COOKIE) {
+            delCookie(name);
+        } else if (type === LOCAL_STORAGE) {
+            removeStorageItem(name);
+        }
     }
 }

--- a/test/lib/storageUtils.spec.js
+++ b/test/lib/storageUtils.spec.js
@@ -1,6 +1,12 @@
-import {expect} from 'chai';
+import chai from 'chai';
 import sinon from "sinon";
+import sinonChai from 'sinon-chai';
 import * as storage from '../../src/lib/storageUtils';
+import * as cookieUtils from "../../src/lib/cookieUtils";
+import {COOKIE, LOCAL_STORAGE} from "../../src/lib/constants";
+
+chai.use(sinonChai);
+const expect = chai.expect;
 
 describe('StorageUtils operations', ()=>{
     afterEach(()=>{
@@ -75,4 +81,96 @@ describe('StorageUtils operations', ()=>{
 
         expect(storage.getStorageItem(key)).to.equal(val);
     });
+});
+
+describe('value functions', ()=>{
+
+    it('readValue cookie', ()=>{
+        const cookieStub = sinon.stub(cookieUtils, 'getCookie');
+        const storageStub = sinon.stub(Storage.prototype, 'getItem');
+        const keyName = 'ANY_KEY';
+
+        storage.readValue(COOKIE, keyName);
+
+        expect(cookieStub).to.have.been.calledOnceWith(keyName);
+        expect(storageStub).to.have.not.been.called;
+        cookieStub.restore();
+        storageStub.restore();
+    });
+
+    it('readValue local storage', ()=>{
+        const cookieStub = sinon.stub(cookieUtils, 'getCookie');
+        const storageStub = sinon.stub(Storage.prototype, 'getItem');
+        const keyName = 'ANY_KEY';
+
+        storage.readValue(LOCAL_STORAGE, keyName);
+
+        expect(storageStub).to.have.been.calledTwice;
+        expect(storageStub.getCall(0).args[0]).to.equal(`${keyName}_exp`);
+        expect(storageStub.getCall(1).args[0]).to.equal(keyName);
+        expect(cookieStub).to.have.not.been.called;
+        storageStub.restore();
+        cookieStub.restore();
+    });
+
+    it('deleteValue cookie', ()=>{
+        const cookieStub = sinon.stub(cookieUtils, 'delCookie');
+        const storageStub = sinon.stub(Storage.prototype, 'removeItem');
+        const keyName = 'ANY_KEY';
+
+        storage.deleteValue(COOKIE, keyName);
+
+        expect(cookieStub).to.have.been.calledOnceWith(keyName);
+        expect(storageStub).to.have.not.been.called;
+        cookieStub.restore();
+        storageStub.restore();
+    });
+
+    it('deleteValue local storage', ()=>{
+        const cookieStub = sinon.stub(cookieUtils, 'delCookie');
+        const storageStub = sinon.stub(Storage.prototype, 'removeItem');
+        const keyName = 'ANY_KEY';
+
+        storage.deleteValue(LOCAL_STORAGE, keyName);
+
+        expect(storageStub).to.have.been.calledTwice;
+        expect(storageStub.getCall(0).args[0]).to.equal(`${keyName}_exp`);
+        expect(storageStub.getCall(1).args[0]).to.equal(keyName);
+        expect(cookieStub).to.have.not.been.called;
+        storageStub.restore();
+        cookieStub.restore();
+    });
+
+    it('writeValue cookie', ()=>{
+        const cookieStub = sinon.stub(cookieUtils, 'setCookie');
+        const storageStub = sinon.stub(Storage.prototype, 'setItem');
+        const keyName = 'ANY_KEY';
+        const value = 'ANY_VALUE';
+        const interval = 42;
+
+        storage.writeValue(COOKIE, keyName, value, interval);
+
+        expect(cookieStub).to.have.been.calledOnceWith(keyName, value, interval);
+        expect(storageStub).to.have.not.been.called;
+        cookieStub.restore();
+        storageStub.restore();
+    });
+
+    it('writeValue local storage', ()=>{
+        const cookieStub = sinon.stub(cookieUtils, 'setCookie');
+        const storageStub = sinon.stub(Storage.prototype, 'setItem');
+        const keyName = 'ANY_KEY';
+        const value = 'ANY_VALUE';
+        const interval = 42;
+
+        storage.writeValue(LOCAL_STORAGE, keyName, value, interval);
+
+        expect(storageStub).to.have.been.calledTwice;
+        expect(storageStub.getCall(0).args[0]).to.equal(`${keyName}_exp`);
+        expect(storageStub.getCall(1).args[0]).to.equal(keyName);
+        expect(cookieStub).to.have.not.been.called;
+        storageStub.restore();
+        cookieStub.restore();
+    });
+
 });


### PR DESCRIPTION
Move readValue, writeValue, and deleteValue to storageUtils.js so they have no direct dependency on PubcidHandler.